### PR TITLE
Fixed crash occurring when a folder gets updated via Finder.

### DIFF
--- a/Sources/SwiftFileSystemEvents/FileSystemEventStream.swift
+++ b/Sources/SwiftFileSystemEvents/FileSystemEventStream.swift
@@ -81,7 +81,7 @@ public final class FileSystemEventStream {
         let eventPaths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as! [CFString]
         let stream = Unmanaged<FileSystemEventStream>.fromOpaque(info).takeUnretainedValue()
         for index in 0..<numEvents {
-            let url = CFURLCreateWithString(nil, eventPaths[index], nil) as URL
+            let url = URL(fileURLWithPath: eventPaths[index] as String)
             let flags = FileSystemEvent.Flags(rawValue: eventFlags[index])
             let id = FileSystemEvent.ID(rawValue: eventIDs[index])
             let event = FileSystemEvent(url: url, id: id, flags: flags)


### PR DESCRIPTION
This proposed change fixes the following crash:

> Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value

The crash occurs on an attempt to change an observed folder via Finder. Eiter by adding or removing files. The crash occurs under macOS 13.4.1, 13.5 and macOS 14-beta. I can reproduce the crash on every attempt on my development Mac under macOS 14. Several of my customers also report this issue.

I can't tell why the original approach is no longer working.